### PR TITLE
Remove extra whitespace on tag details view

### DIFF
--- a/src/layouts/Main/Main.module.scss
+++ b/src/layouts/Main/Main.module.scss
@@ -10,10 +10,10 @@
 
 .container {
   display: flex;
+  margin-top: 25px;
   flex-direction: row;
   justify-content: flex-start;
   align-items: flex-start;
-  margin-top: t.$nav-height;
   height: calc(100vh - #{t.$nav-height});
   width: 100vw;
 }


### PR DESCRIPTION
after:

![image](https://user-images.githubusercontent.com/31543997/125884043-64581c93-3ddb-427f-ae4a-969959f305c9.png)


before:
![image](https://user-images.githubusercontent.com/31543997/125884079-87e0bc4c-7aa7-4257-afb0-540a0049d57b.png)
